### PR TITLE
fix: length of the result buffer may less than the nodeCrypto's

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -47,16 +47,18 @@ function _testIt (keys, message, t) {
   var pub = keys.public
   var priv = keys.private
   t.test(message.toString(), function (t) {
-    t.plan(8)
+    t.plan(10)
 
     var myEnc = myCrypto.publicEncrypt(pub, message)
     var nodeEnc = nodeCrypto.publicEncrypt(pub, message)
+    t.equals(myEnc.length, nodeEnc.length, 'my public encrypted length node public encrypted length')
     t.equals(myCrypto.privateDecrypt(priv, myEnc).toString('hex'), message.toString('hex'), 'my decrypter my message')
     t.equals(myCrypto.privateDecrypt(priv, nodeEnc).toString('hex'), message.toString('hex'), 'my decrypter node\'s message')
     t.equals(nodeCrypto.privateDecrypt(priv, myEnc).toString('hex'), message.toString('hex'), 'node decrypter my message')
     t.equals(nodeCrypto.privateDecrypt(priv, nodeEnc).toString('hex'), message.toString('hex'), 'node decrypter node\'s message')
     myEnc = myCrypto.privateEncrypt(priv, message)
     nodeEnc = nodeCrypto.privateEncrypt(priv, message)
+    t.equals(myEnc.length, nodeEnc.length, 'my public private length node private encrypted length')
     t.equals(myCrypto.publicDecrypt(pub, myEnc).toString('hex'), message.toString('hex'), 'reverse methods my decrypter my message')
     t.equals(myCrypto.publicDecrypt(pub, nodeEnc).toString('hex'), message.toString('hex'), 'reverse methods my decrypter node\'s message')
     t.equals(nodeCrypto.publicDecrypt(pub, myEnc).toString('hex'), message.toString('hex'), 'reverse methods node decrypter my message')

--- a/withPublic.js
+++ b/withPublic.js
@@ -6,7 +6,7 @@ function withPublic (paddedMsg, key) {
     .toRed(BN.mont(key.modulus))
     .redPow(new BN(key.publicExponent))
     .fromRed()
-    .toArray())
+    .toArray('be', key.modulus.byteLength()))
 }
 
 module.exports = withPublic


### PR DESCRIPTION
Add the following codes in test
```js
t.equals(myEnc.length, nodeEnc.length, 'my public encrypted length node public encrypted length')
```
and find the bug.

I think the results should have the same length.